### PR TITLE
Fix undefined contextInfo reference

### DIFF
--- a/src/utils/getConversationMessage.ts
+++ b/src/utils/getConversationMessage.ts
@@ -44,7 +44,7 @@ const getTypeMessage = (msg: any) => {
         }`
       : undefined,
     externalAdReplyBody: msg?.contextInfo?.externalAdReply?.body
-      ? `externalAdReplyBody|${msg.contextInfo.externalAdReply.body}`
+      ? `externalAdReplyBody|${msg.contextInfo?.externalAdReply?.body}`
       : undefined,
   };
 


### PR DESCRIPTION
## Summary
- ensure externalAdReply body check handles missing contextInfo

## Testing
- `npm test` *(fails: Cannot find module './test/all.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_6867691102ec8320aefad06713c21b15